### PR TITLE
Make v1.0.0 compatible

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+on: push
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+          key: ${{ runner.os }}-cabal-cache
+
+      - name: Build
+        run: cabal v2-update && cabal v2-install validator
+
+      - name: Install toml-test
+        run: |
+          FILE=toml-test-v1.1.0-linux-amd64
+          curl -sSLO "https://github.com/BurntSushi/toml-test/releases/download/v1.1.0/${FILE}.gz"
+          gunzip "${FILE}.gz"
+          chmod +x "${FILE}"
+          mv "${FILE}" /usr/local/bin/toml-test
+
+      - name: Validate
+        run: |
+          PATH=~/.cabal/bin:$PATH
+          toml-test toml-parser-validator

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,55 @@ jobs:
           chmod +x "${FILE}"
           mv "${FILE}" /usr/local/bin/toml-test
 
+      # TODO: remove all "-skip" flags
       - name: Validate
         run: |
           PATH=~/.cabal/bin:$PATH
-          toml-test toml-parser-validator
+          toml-test toml-parser-validator \
+            -skip valid/inline-table/key-dotted \
+            -skip valid/key/dotted \
+            -skip valid/key/numeric-dotted \
+            -skip valid/string/multiline-quotes \
+            -skip valid/string/multiline \
+            -skip valid/table/array-nest \
+            -skip valid/table/array-table-array \
+            -skip valid/table/names \
+            -skip invalid/control/bare-cr \
+            -skip invalid/control/comment-cr \
+            -skip invalid/control/comment-del \
+            -skip invalid/control/comment-lf \
+            -skip invalid/control/comment-null \
+            -skip invalid/control/comment-us \
+            -skip invalid/control/multi-del \
+            -skip invalid/control/multi-lf \
+            -skip invalid/control/multi-null \
+            -skip invalid/control/multi-us \
+            -skip invalid/control/rawmulti-del \
+            -skip invalid/control/rawmulti-lf \
+            -skip invalid/control/rawmulti-null \
+            -skip invalid/control/rawmulti-us \
+            -skip invalid/control/rawstring-del \
+            -skip invalid/control/rawstring-lf \
+            -skip invalid/control/rawstring-null \
+            -skip invalid/control/rawstring-us \
+            -skip invalid/control/string-bs \
+            -skip invalid/control/string-del \
+            -skip invalid/control/string-lf \
+            -skip invalid/control/string-null \
+            -skip invalid/control/string-us \
+            -skip invalid/inline-table/add \
+            -skip invalid/inline-table/linebreak-1 \
+            -skip invalid/inline-table/linebreak-2 \
+            -skip invalid/inline-table/linebreak-3 \
+            -skip invalid/inline-table/linebreak-4 \
+            -skip invalid/key/after-array \
+            -skip invalid/key/after-table \
+            -skip invalid/key/after-value \
+            -skip invalid/key/multiline \
+            -skip invalid/key/newline \
+            -skip invalid/key/no-eol \
+            -skip invalid/string/bad-codepoint \
+            -skip invalid/table/duplicate-table-array \
+            -skip invalid/table/duplicate \
+            -skip invalid/table/llbrace \
+            -skip invalid/table/rrbrace

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,55 +24,7 @@ jobs:
           chmod +x "${FILE}"
           mv "${FILE}" /usr/local/bin/toml-test
 
-      # TODO: remove all "-skip" flags
       - name: Validate
         run: |
           PATH=~/.cabal/bin:$PATH
-          toml-test toml-parser-validator \
-            -skip valid/inline-table/key-dotted \
-            -skip valid/key/dotted \
-            -skip valid/key/numeric-dotted \
-            -skip valid/string/multiline-quotes \
-            -skip valid/string/multiline \
-            -skip valid/table/array-nest \
-            -skip valid/table/array-table-array \
-            -skip valid/table/names \
-            -skip invalid/control/bare-cr \
-            -skip invalid/control/comment-cr \
-            -skip invalid/control/comment-del \
-            -skip invalid/control/comment-lf \
-            -skip invalid/control/comment-null \
-            -skip invalid/control/comment-us \
-            -skip invalid/control/multi-del \
-            -skip invalid/control/multi-lf \
-            -skip invalid/control/multi-null \
-            -skip invalid/control/multi-us \
-            -skip invalid/control/rawmulti-del \
-            -skip invalid/control/rawmulti-lf \
-            -skip invalid/control/rawmulti-null \
-            -skip invalid/control/rawmulti-us \
-            -skip invalid/control/rawstring-del \
-            -skip invalid/control/rawstring-lf \
-            -skip invalid/control/rawstring-null \
-            -skip invalid/control/rawstring-us \
-            -skip invalid/control/string-bs \
-            -skip invalid/control/string-del \
-            -skip invalid/control/string-lf \
-            -skip invalid/control/string-null \
-            -skip invalid/control/string-us \
-            -skip invalid/inline-table/add \
-            -skip invalid/inline-table/linebreak-1 \
-            -skip invalid/inline-table/linebreak-2 \
-            -skip invalid/inline-table/linebreak-3 \
-            -skip invalid/inline-table/linebreak-4 \
-            -skip invalid/key/after-array \
-            -skip invalid/key/after-table \
-            -skip invalid/key/after-value \
-            -skip invalid/key/multiline \
-            -skip invalid/key/newline \
-            -skip invalid/key/no-eol \
-            -skip invalid/string/bad-codepoint \
-            -skip invalid/table/duplicate-table-array \
-            -skip invalid/table/duplicate \
-            -skip invalid/table/llbrace \
-            -skip invalid/table/rrbrace
+          toml-test toml-parser-validator

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ toml-parser
 [![Hackage](https://img.shields.io/hackage/v/toml-parser.svg)](https://hackage.haskell.org/package/toml-parser) [![Build Status](https://secure.travis-ci.org/glguy/toml-parser.png?branch=master)](http://travis-ci.org/glguy/toml-parser)
 
 This package provides a complete and light-weight parser for the TOML
-configuration language. TOML is specified by <https://github.com/toml-lang/toml>.
+configuration language. This package adheres to the v1.0.0 spec, as validated
+by [`toml-test`](https://github.com/BurntSushi/toml-test).
+TOML is specified by <https://github.com/toml-lang/toml>.
 This language is designed to be easy to understand and unambiguous.
 
 This implementation uses Alex and Happy to generate an efficient lexer

--- a/src/TOML/Lexer.x
+++ b/src/TOML/Lexer.x
@@ -35,6 +35,8 @@ $hexdigit       = [0-9 a-f A-F]
 @fractpart      = $digit+ (\_ $digit+)*
 @integer        = [\-\+]? (0 | [1-9] $digit* (\_ $digit+)*)
 @double         = @integer (\. @fractpart)? ([eE] @integer)?
+@inf            = [\-\+]? "inf"
+@nan            = [\-\+]? "nan"
 
 
 @day            = $digit+   \- $digit{2} \- $digit{2}
@@ -58,6 +60,8 @@ $white+                 ;
 "="                     { token_ EqualToken             }
 @integer                { token integer                 }
 @double                 { token double                  }
+@inf                    { token InfToken                }
+@nan                    { token NanToken                }
 "true"                  { token_ TrueToken              }
 "false"                 { token_ FalseToken             }
 @localtime              { token localtime               }

--- a/src/TOML/Lexer.x
+++ b/src/TOML/Lexer.x
@@ -24,6 +24,8 @@ import           TOML.Located
 
 $alpha          = [A-Z a-z]
 $digit          = [0-9]
+$bindigit       = [0-1]
+$octdigit       = [0-7]
 $hexdigit       = [0-9 a-f A-F]
 
 @decimal        = $digit+
@@ -34,6 +36,9 @@ $hexdigit       = [0-9 a-f A-F]
 
 @fractpart      = $digit+ (\_ $digit+)*
 @integer        = [\-\+]? (0 | [1-9] $digit* (\_ $digit+)*)
+@bin_int        = 0 b $bindigit+ (\_ $bindigit+)*
+@oct_int        = 0 o $octdigit+ (\_ $octdigit+)*
+@hex_int        = 0 x $hexdigit+ (\_ $hexdigit+)*
 @double         = @integer (\. @fractpart)? ([eE] [\-\+]? $digit+ (\_ $digit+)*)?
 @inf            = [\-\+]? "inf"
 @nan            = [\-\+]? "nan"
@@ -59,6 +64,9 @@ $white+                 ;
 "."                     { token_ PeriodToken            }
 "="                     { token_ EqualToken             }
 @integer                { token integer                 }
+@bin_int                { token prefixedInt             }
+@oct_int                { token prefixedInt             }
+@hex_int                { token prefixedInt             }
 @double                 { token double                  }
 @inf                    { token InfToken                }
 @nan                    { token NanToken                }

--- a/src/TOML/Lexer.x
+++ b/src/TOML/Lexer.x
@@ -39,7 +39,7 @@ $hexdigit       = [0-9 a-f A-F]
 
 @day            = $digit+   \- $digit{2} \- $digit{2}
 @timeofday      = $digit{2} \: $digit{2} \: $digit{2} (\. $digit*)?
-@localtime      = @day T @timeofday
+@localtime      = @day (T | t | $white) @timeofday
 @zonedtime      = @localtime ( $alpha | [\+\-] $digit{2} \:? $digit{2} )
 
 

--- a/src/TOML/Lexer.x
+++ b/src/TOML/Lexer.x
@@ -34,7 +34,7 @@ $hexdigit       = [0-9 a-f A-F]
 
 @fractpart      = $digit+ (\_ $digit+)*
 @integer        = [\-\+]? (0 | [1-9] $digit* (\_ $digit+)*)
-@double         = @integer (\. @fractpart)? ([eE] @integer)?
+@double         = @integer (\. @fractpart)? ([eE] [\-\+]? $digit+ (\_ $digit+)*)?
 @inf            = [\-\+]? "inf"
 @nan            = [\-\+]? "nan"
 

--- a/src/TOML/LexerUtils.hs
+++ b/src/TOML/LexerUtils.hs
@@ -51,7 +51,13 @@ import           Data.Char (isSpace, isControl, isAscii, ord, chr)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Read as Text
-import           Data.Time (ParseTime, parseTimeOrError, defaultTimeLocale, iso8601DateFormat)
+import           Data.Time ( LocalTime (..)
+                           , ParseTime
+                           , ZonedTime (..)
+                           , parseTimeOrError
+                           , defaultTimeLocale
+                           , iso8601DateFormat
+                           )
 import           Data.Word (Word8)
 
 import           TOML.Tokens
@@ -228,9 +234,13 @@ timeFormat :: String
 timeFormat = "%T%Q"
 
 
+normalizeDateTime :: Text -> Text
+normalizeDateTime = Text.map (\c -> if c `elem` "Tt " then 'T' else c)
+
+
 -- | Date and time lexeme parsers
 zonedtime, localtime, day, timeofday :: Text -> Token
-zonedtime = timeParser ZonedTimeToken (iso8601DateFormat (Just timeFormat)++"%Z")
-localtime = timeParser LocalTimeToken (iso8601DateFormat (Just timeFormat))
+zonedtime = timeParser ZonedTimeToken (iso8601DateFormat (Just timeFormat)++"%Z") . normalizeDateTime
+localtime = timeParser LocalTimeToken (iso8601DateFormat (Just timeFormat)) . normalizeDateTime
 day       = timeParser DayToken       (iso8601DateFormat Nothing)
 timeofday = timeParser TimeOfDayToken timeFormat

--- a/src/TOML/LexerUtils.hs
+++ b/src/TOML/LexerUtils.hs
@@ -195,9 +195,9 @@ integer str = IntegerToken n
 
 -- | Construct a 'Double' token from a lexeme.
 double :: Text {- ^ lexeme -} -> Token
-double str = DoubleToken n
+double str = DoubleToken $ fromRational n
   where
-  Right (n,_) = Text.signed Text.double (Text.filter (/= '_') str)
+  Right (n,_) = Text.rational (Text.filter (/= '_') str)
 
 
 -- | Construct a 'BareKeyToken' for the given lexeme. This operation

--- a/src/TOML/Parser.y
+++ b/src/TOML/Parser.y
@@ -17,6 +17,7 @@ import Data.Text (Text,pack)
 import TOML.Components
 import TOML.Errors
 import TOML.Located
+import TOML.ParserUtils
 import TOML.Tokens
 import TOML.Value
 
@@ -124,20 +125,11 @@ inlinearrayR ::                 { [Value]                       }
 
 {
 
--- | This operation is called by happy when no production matches the
--- current token list.
-errorP :: [Located Token] {- ^ nonempty remainig tokens -} -> Either TOMLError a
-errorP = Left . Unexpected . head
-
 -- | Attempt to parse a layout annotated token stream or
 -- the token that caused the parse to fail.
 parseComponents ::
   [Located Token]              {- ^ layout annotated token stream -} ->
   Either TOMLError [Component] {- ^ token at failure or result -}
 parseComponents = components
-
--- | Abort the parse with an error indicating that the given token was unmatched.
-unterminated :: Located Token -> Either TOMLError a
-unterminated = Left . Unterminated
 
 }

--- a/src/TOML/Parser.y
+++ b/src/TOML/Parser.y
@@ -29,6 +29,8 @@ STRING                          { Located _ (StringToken $$)    }
 BAREKEY                         { Located _ (BareKeyToken $$)   }
 INTEGER                         { Located _ (IntegerToken $$)   }
 DOUBLE                          { Located _ (DoubleToken $$)    }
+INF                             { Located _ InfToken{}          }
+NAN                             { Located _ NanToken{}          }
 'true'                          { Located _ TrueToken           }
 'false'                         { Located _ FalseToken          }
 '['                             { $$@(Located _ LeftBracketToken)}
@@ -86,12 +88,16 @@ key ::                          { Text                          }
   : BAREKEY                     { $1                            }
   | STRING                      { $1                            }
   | INTEGER                     { pack (show $1)                }
+  | INF                         {% getInfKey $1                 }
+  | NAN                         {% getNanKey $1                 }
   | 'true'                      { pack "true"                   }
   | 'false'                     { pack "false"                  }
 
 value ::                        { Value                         }
   : INTEGER                     { Integer    $1                 }
   | DOUBLE                      { Double     $1                 }
+  | INF                         { getInfValue $1                }
+  | NAN                         { getNanValue $1                }
   | STRING                      { String     $1                 }
   | ZONEDTIME                   { ZonedTimeV $1                 }
   | TIMEOFDAY                   { TimeOfDayV $1                 }

--- a/src/TOML/ParserUtils.hs
+++ b/src/TOML/ParserUtils.hs
@@ -1,0 +1,31 @@
+{-|
+Module      : TOML.ParserUtils
+Description : /Internal:/ Parser support operations for TOML
+Copyright   : (c) Eric Mertens, 2017
+License     : ISC
+Maintainer  : emertens@gmail.com
+
+This module is separate from the Parser.y input to Happy
+to segregate the automatically generated code from the
+hand written code. The automatically generated code
+causes lots of warnings which mask the interesting warnings.
+-}
+module TOML.ParserUtils
+  (
+  -- * Errors
+    errorP
+  , unterminated
+  ) where
+
+import           TOML.Errors
+import           TOML.Located
+import           TOML.Tokens
+
+-- | This operation is called by happy when no production matches the
+-- current token list.
+errorP :: [Located Token] {- ^ nonempty remainig tokens -} -> Either TOMLError a
+errorP = Left . Unexpected . head
+
+-- | Abort the parse with an error indicating that the given token was unmatched.
+unterminated :: Located Token -> Either TOMLError a
+unterminated = Left . Unterminated

--- a/src/TOML/Tokens.hs
+++ b/src/TOML/Tokens.hs
@@ -34,6 +34,8 @@ data Token
   | LeftBraceToken           -- ^ @{@
   | RightBraceToken          -- ^ @}@
   | EqualToken               -- ^ @=@
+  | InfToken Text            -- ^ @inf@, @-inf@, @+inf@
+  | NanToken Text            -- ^ @nan@, @-nan@, @+nan@
   | TrueToken                -- ^ @true@
   | FalseToken               -- ^ @false@
   | ErrorToken LexerError    -- ^ lexical error

--- a/toml-parser.cabal
+++ b/toml-parser.cabal
@@ -28,7 +28,8 @@ source-repository head
 library
   exposed-modules:     TOML
   other-modules:       TOML.Tokens TOML.LexerUtils TOML.Lexer TOML.Errors
-                       TOML.Parser TOML.Components TOML.Value TOML.Located
+                       TOML.Parser TOML.ParserUtils TOML.Components TOML.Value
+                       TOML.Located
   build-depends:       base  >=4.8 && <4.15,
                        array >=0.5 && <0.6,
                        text  >=1.2 && <1.3,

--- a/validator/Main.hs
+++ b/validator/Main.hs
@@ -10,7 +10,7 @@ module Main (main) where
 import           Control.Exception
 import qualified Data.Aeson as A
 import           Data.Text (Text)
-import           Data.Time
+import           Data.Time.Format.ISO8601 (iso8601Show)
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Map as Map
 import qualified Data.Text.IO as Text
@@ -35,14 +35,10 @@ convertValue v =
     Integer    x -> convertLeaf "integer" (show x)
     String     x -> convertLeaf "string" x
     Bool       x -> convertLeaf "bool" (if x then "true" else "false")
-    ZonedTimeV x -> convertDatetime x (iso8601DateFormat (Just "%T%Q%Z"))
-    LocalTimeV x -> convertDatetime x (iso8601DateFormat (Just "%T%Q"))
-    DayV       x -> convertDatetime x (iso8601DateFormat Nothing)
-    TimeOfDayV x -> convertDatetime x "%T%Q"
-
-convertDatetime :: FormatTime t => t -> String -> A.Value
-convertDatetime x fmt =
-  convertLeaf "datetime" (formatTime defaultTimeLocale fmt x)
+    ZonedTimeV x -> convertLeaf "datetime" (iso8601Show x)
+    LocalTimeV x -> convertLeaf "datetime-local" (iso8601Show x)
+    DayV       x -> convertLeaf "date-local" (iso8601Show x)
+    TimeOfDayV x -> convertLeaf "time-local" (iso8601Show x)
 
 convertLeaf :: A.ToJSON a => String -> a -> A.Value
 convertLeaf tyname val =

--- a/validator/Main.hs
+++ b/validator/Main.hs
@@ -31,7 +31,7 @@ convertValue v =
   case v of
     List       x -> A.toJSON (map convertValue x)
     Table      x -> convertTable x
-    Double     x -> convertLeaf "float" (show x)
+    Double     x -> convertLeaf "float" (showFloat x)
     Integer    x -> convertLeaf "integer" (show x)
     String     x -> convertLeaf "string" x
     Bool       x -> convertLeaf "bool" (if x then "true" else "false")
@@ -39,6 +39,12 @@ convertValue v =
     LocalTimeV x -> convertLeaf "datetime-local" (iso8601Show x)
     DayV       x -> convertLeaf "date-local" (iso8601Show x)
     TimeOfDayV x -> convertLeaf "time-local" (iso8601Show x)
+
+showFloat :: Double -> String
+showFloat x
+  | isNaN x = "nan"
+  | isInfinite x = if x < 0 then "-inf" else "inf"
+  | otherwise = show x
 
 convertLeaf :: A.ToJSON a => String -> a -> A.Value
 convertLeaf tyname val =


### PR DESCRIPTION
Resolves #5 
Blocked on #11 + other PRs to unskip failing tests

When this is merged, we should make a release, add toml-parser to the [v1.0.0 compatibility section in the TOML wiki](https://github.com/toml-lang/toml/wiki#v100-compliant), and make an announcement to the Haskell + TOML communities!