### PR TITLE
Pad year to four zeros

### DIFF
--- a/src/Toml/Pretty.hs
+++ b/src/Toml/Pretty.hs
@@ -181,10 +181,10 @@ prettyValue = \case
     TimeOfDay tod       -> annotate DateClass (fromString (formatTime defaultTimeLocale "%H:%M:%S%Q" tod))
     ZonedTime zt
         | timeZoneMinutes (zonedTimeZone zt) == 0 ->
-                           annotate DateClass (fromString (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" zt))
-        | otherwise     -> annotate DateClass (fromString (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Q%Ez" zt))
-    LocalTime lt        -> annotate DateClass (fromString (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Q" lt))
-    Day d               -> annotate DateClass (fromString (formatTime defaultTimeLocale "%Y-%m-%d" d))
+                           annotate DateClass (fromString (formatTime defaultTimeLocale "%0Y-%m-%dT%H:%M:%S%QZ" zt))
+        | otherwise     -> annotate DateClass (fromString (formatTime defaultTimeLocale "%0Y-%m-%dT%H:%M:%S%Q%Ez" zt))
+    LocalTime lt        -> annotate DateClass (fromString (formatTime defaultTimeLocale "%0Y-%m-%dT%H:%M:%S%Q" lt))
+    Day d               -> annotate DateClass (fromString (formatTime defaultTimeLocale "%0Y-%m-%d" d))
 
 prettySmartString :: String -> TomlDoc
 prettySmartString str


### PR DESCRIPTION
Otherwise dates before 1000 will be printed wrong: before:

	% ./TomlEncoder <<<'{"first-date": {"type": "date-local", "value": "0001-01-01"}}'
	first-date = 1-01-01

After:

	% ./TomlEncoder <<<'{"first-date": {"type": "date-local", "value": "0001-01-01"}}'
	first-date = 0001-01-01

This is a new test in toml-test (not yet in any release), and noticed it's the only failing test when I added toml-parser to https://arp242.github.io/toml-test-matrix/, and seemed simple enough to fix.