### PR TITLE
Preserve key insertion order with OMap and make alphabetical sorting opt-in

### DIFF
--- a/src/Toml/Pretty.hs
+++ b/src/Toml/Pretty.hs
@@ -245,7 +245,7 @@ isSingularTable _ = False
 -- | Render a complete TOML document using top-level table and array of
 -- table sections where possible.
 --
--- Keys are sorted alphabetically. To provide a custom ordering, see
+-- Keys preserve table order. To provide a custom ordering, see
 -- 'prettyTomlOrdered'.
 prettyToml ::
     Table' a {- ^ table to print -} ->
@@ -295,7 +295,7 @@ prettyTomlOrdered proj = prettyToml_ (KeyProjection proj) TableKind []
 
 -- | Optional projection used to order rendered tables
 data KeyProjection where
-    -- | No projection provided; alphabetical order used
+    -- | No projection provided; preserve existing table order
     NoProjection :: KeyProjection
     -- | Projection provided: table name and current key are available
     KeyProjection :: Ord a => ([Text] -> Text -> a) -> KeyProjection

--- a/src/Toml/Schema/FromValue.hs
+++ b/src/Toml/Schema/FromValue.hs
@@ -75,6 +75,7 @@ mapOf ::
     Value' l -> Matcher l (Map k v)
 mapOf matchKey matchVal = fmap Map.fromList . pairsOf matchKey matchVal
 
+-- | Like 'mapOf' but producing an 'OMap' preserving table key order.
 omapOf ::
     Ord k =>
     (l -> Text -> Matcher l k)         {- ^ key matcher   -} ->

--- a/src/Toml/Schema/ParseTable.hs
+++ b/src/Toml/Schema/ParseTable.hs
@@ -36,7 +36,7 @@ import Control.Monad.Trans.Reader (ReaderT(..), ask)
 import Control.Monad.Trans.State.Strict (StateT(..), get, put)
 import Data.Foldable (for_)
 import Data.List (intercalate)
-import Data.Map qualified as Map
+import Data.Map.Ordered qualified as OMap
 import Data.Text (Text)
 import Toml.Schema.Matcher (Matcher, inKey, failAt, warn, warnAt)
 import Toml.Semantics (Table'(..), Value')
@@ -67,7 +67,7 @@ liftMatcher = ParseTable . lift . lift
 parseTable :: ParseTable l a -> l -> Table' l -> Matcher l a
 parseTable (ParseTable p) l t =
  do (x, MkTable t') <- runStateT (runReaderT p l) t
-    for_ (Map.assocs t') \(k, (a, _)) ->
+    for_ (OMap.assocs t') \(k, (a, _)) ->
         warnAt a ("unexpected key: " ++ show (prettySimpleKey k))
     pure x
 
@@ -114,10 +114,10 @@ pickKey xs =
     where
         f _ (Else m) _ = liftMatcher m
         f t (Key k c) continue =
-            case Map.lookup k t of
+            case OMap.lookup k t of
                 Nothing -> continue
                 Just (_, v) ->
-                 do setTable $! MkTable (Map.delete k t)
+                 do setTable $! MkTable (OMap.delete k t)
                     liftMatcher (inKey k (c v))
 
         errCase =

--- a/src/Toml/Schema/ToValue.hs
+++ b/src/Toml/Schema/ToValue.hs
@@ -112,8 +112,7 @@ instance ToTable (Table' a) where
 instance ToValue (Table' a) where
     toValue = defaultTableToValue
 
--- | Convert to a table key. This class enables various string types to be
--- used as the keys of a 'Map' when converting into TOML tables.
+-- | Convert to a table key. Enables various string types for table keys.
 class ToKey a where
     toKey :: a -> Text
 

--- a/src/Toml/Schema/ToValue.hs
+++ b/src/Toml/Schema/ToValue.hs
@@ -34,6 +34,8 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
 import Data.Map qualified as Map
+import Data.Map.Ordered (OMap)
+import Data.Map.Ordered qualified as OMap
 import Data.Ratio (Ratio)
 import Data.Sequence (Seq)
 import Data.Text (Text)
@@ -48,7 +50,7 @@ import Toml.Semantics
 --
 -- Use '.=' for a convenient way to build the pairs.
 table :: [(Text, Value)] -> Table
-table kvs = MkTable (Map.fromList [(k, ((), v)) | (k, v) <- kvs])
+table kvs = MkTable (OMap.fromList [(k, ((), v)) | (k, v) <- kvs])
 {-# INLINE table #-}
 
 -- | Convenience function for building key-value pairs while
@@ -96,6 +98,12 @@ instance (ToKey k, ToValue v) => ToTable (Map k v) where
     toTable m = table [(toKey k, toValue v) | (k,v) <- Map.assocs m]
 
 instance (ToKey k, ToValue v) => ToValue (Map k v) where
+    toValue = defaultTableToValue
+
+instance (ToKey k, ToValue v) => ToTable (OMap k v) where
+    toTable m = table [(toKey k, toValue v) | (k,v) <- OMap.assocs m]
+
+instance (ToKey k, ToValue v) => ToValue (OMap k v) where
     toValue = defaultTableToValue
 
 instance ToTable (Table' a) where

--- a/src/Toml/Semantics.hs
+++ b/src/Toml/Semantics.hs
@@ -7,7 +7,7 @@ Copyright   : (c) Eric Mertens, 2023
 License     : ISC
 Maintainer  : emertens@gmail.com
 
-This module extracts a nested Map representation of a TOML
+This module extracts a nested ordered map representation of a TOML
 file. It detects invalid key assignments and resolves dotted
 key assignments.
 
@@ -229,7 +229,7 @@ invalidKey ::
     M a b
 invalidKey (a, key) kind = Left (SemanticError a key kind)
 
--- | Specialization of 'Map.alterF' used to adjust a location in a 'FrameTable'
+-- | Adjust a key in a 'FrameTable' preserving insertion order and annotations.
 alterFrame ::
     (a, Text)                  {- ^ annotated key     -} ->
     M a (Frame a)              {- ^ new value case    -} ->

--- a/src/Toml/Semantics/Types.hs
+++ b/src/Toml/Semantics/Types.hs
@@ -8,7 +8,7 @@ Maintainer  : emertens@gmail.com
 
 This module provides the type for the semantics of a TOML file.
 All dotted keys are resolved in this representation. Each table
-is a Map with a single level of keys.
+is an ordered map with a single level of keys.
 
 Values are parameterized over an annotation type to allow values
 to be attributed to a file location. When values are constructed

--- a/src/Toml/Semantics/Types.hs
+++ b/src/Toml/Semantics/Types.hs
@@ -37,7 +37,7 @@ module Toml.Semantics.Types (
     valueType,
     ) where
 
-import Data.Map (Map)
+import Data.Map.Ordered (OMap)
 import Data.String (IsString(fromString))
 import Data.Text (Text)
 import Data.Time (Day, LocalTime, TimeOfDay, ZonedTime(zonedTimeToLocalTime, zonedTimeZone), timeZoneMinutes)
@@ -132,7 +132,7 @@ valueType = \case
     ZonedTime' {} -> "offset date-time"
 
 -- | A table with annotated keys and values.
-newtype Table' a = MkTable (Map Text (a, Value' a))
+newtype Table' a = MkTable (OMap Text (a, Value' a))
     deriving (
         Show        {- ^ Default instance -},
         Read        {- ^ Default instance -},

--- a/test/DecodeSpec.hs
+++ b/test/DecodeSpec.hs
@@ -95,15 +95,15 @@ spec =
             [[fruits]]
             name = "apple"
 
-            [fruits.physical]
-            color = "red"
-            shape = "round"
-
             [[fruits.varieties]]
             name = "red delicious"
 
             [[fruits.varieties]]
             name = "granny smith"
+
+            [fruits.physical]
+            color = "red"
+            shape = "round"
 
             [[fruits]]
             name = "banana"
@@ -122,8 +122,8 @@ spec =
             color = "yellow"|]
         `shouldBe`
         Success [
-            "4:1: unexpected key: count in fruits[0]",
             "3:1: unexpected key: taste in fruits[0]",
+            "4:1: unexpected key: count in fruits[0]",
             "7:1: unexpected key: color in fruits[1]"]
             (Fruits [Fruit "peach" Nothing [], Fruit "pineapple" Nothing []])
 

--- a/toml-parser.cabal
+++ b/toml-parser.cabal
@@ -70,13 +70,14 @@ library
         Toml.Syntax.LexerUtils
         Toml.Syntax.ParserUtils
     build-depends:
-        array           ^>= 0.5,
-        base            ^>= {4.14, 4.15, 4.16, 4.17, 4.18, 4.19, 4.20, 4.21},
-        containers      ^>= {0.5, 0.6, 0.7, 0.8},
-        prettyprinter   ^>= 1.7,
-        text            >= 0.2 && < 3,
-        time            ^>= {1.9, 1.10, 1.11, 1.12, 1.14, 1.15},
-        transformers    ^>= {0.5, 0.6},
+        array              ^>= 0.5,
+        base               ^>= {4.14, 4.15, 4.16, 4.17, 4.18, 4.19, 4.20, 4.21},
+        containers         ^>= {0.5, 0.6, 0.7, 0.8},
+        ordered-containers ^>= {0.2.4},
+        prettyprinter      ^>= 1.7,
+        text               >= 0.2 && < 3,
+        time               ^>= {1.9, 1.10, 1.11, 1.12, 1.14, 1.15},
+        transformers       ^>= {0.5, 0.6},
     build-tool-depends:
         alex:alex       >= 3.2,
         happy:happy     >= 1.19,


### PR DESCRIPTION
## Motivation

Preserving insertion order matches how people read/edit TOML and keeps original key order in round-trips. Sorting is easy to add (e.g., `prettyTomlOrdered` with `Down`), but once order is discarded you can't recover the original order without extra (boilerplate) information.

## Changes

- Core representation uses `OMap`. `Table'` now stores keys in insertion order. All semantic constructions respect that.
- `alterFrame` inserts new keys at the end and updates in place, preserving both order and annotations.
- Decoding: `omapOf` provided to decode tables into `OMap` while reusing the same traversal as `mapOf`.
- Printing: `prettyToml` preserves table order by default.
- Updated the tests to reflect new semantics.